### PR TITLE
feat - add basic files and langchain generation support using llama cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Custom
+*.gguf
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/api.py
+++ b/api.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from langchain.chains import LLMChain
+
+from database import Retrospective, get_db_session
+from model import get_chain
+from schemas import (
+    ModelGenerationRequest,
+    ModelGenerationResponse,
+    RetrospectiveRequest, 
+    RetrospectiveResponse
+)
+
+
+router = APIRouter()
+
+
+
+
+@router.post("/generate/chain")
+async def generate_chain(request: ModelGenerationRequest,
+                         chain: LLMChain = Depends(get_chain)) -> ModelGenerationResponse:
+    
+    context = {
+        "input": "너는 사용자에게 도움을 주는 AI야",
+        "instruction": request.text
+    }
+    
+    result = await chain.ainvoke(input=context, max_tokens=100, temperature=0.6, top_p=1, verbose=True)
+
+    return ModelGenerationResponse(text=result.get("text"))
+
+
+@router.post("/predict")
+async def predict(request: RetrospectiveRequest,
+                  chain: LLMChain = Depends(get_chain),
+                  db: AsyncSession = Depends(get_db_session)) -> RetrospectiveResponse:
+    
+
+    return RetrospectiveResponse(text="response")
+    
+    
+
+
+

--- a/config.py
+++ b/config.py
@@ -1,0 +1,26 @@
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+DB_USERNAME = os.environ.get("DB_USERNAME") 
+DB_PASSWORD = os.environ.get("DB_PASSWORD")
+DB_HOST = os.environ.get("DB_HOST")
+DB_NAME = os.environ.get("DB_NAME")
+DB_URL = f"postgresql+asyncpg://{DB_USERNAME}:{DB_PASSWORD}@{DB_HOST}/{DB_NAME}"
+SUMMARY_MODEL_PATH = os.environ.get("SUMMARY_MODEL_PATH")
+RETROSPECTIVE_MODEL_PATH = os.environ.get("RETROSPECTIVE_MODEL_PATH")
+
+
+class Config(BaseSettings):
+    db_url: str = Field(default=DB_URL, env="DB_URL")
+    summary_model_path: str = Field(default=SUMMARY_MODEL_PATH, env="SUMMARY_MODEL_PATH") # transformers
+    retrospective_model_path: str = Field(default=RETROSPECTIVE_MODEL_PATH, env="RETROSPECTIVE_MODEL_PATH") # langchain llamacpp gguf
+    
+
+
+config = Config()

--- a/database.py
+++ b/database.py
@@ -1,0 +1,32 @@
+from sqlmodel import SQLModel, Field
+from typing import Optional, List
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+
+import datetime
+from uuid import UUID, uuid4
+from config import config
+
+
+class Retrospective(SQLModel, table=True):
+    id: Optional[UUID] = Field(default_factory=uuid4, primary_key=True)
+    username: str
+    text: str
+    created_at: datetime.datetime = Field(default_factory=datetime.datetime.now)
+
+
+engine = create_async_engine(config.db_url, echo=False)
+
+
+AsyncSessionLocal = async_sessionmaker(
+    autoflush=False, autocommit=False, bind=engine, class_=AsyncSession
+)
+
+async def get_db_session():
+    async with AsyncSessionLocal() as session:
+        try: 
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+        finally:
+            await session.close()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,49 @@
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from sqlmodel import SQLModel
+from loguru import logger
+
+from api import router
+from database import engine, Retrospective
+from model import load_chain
+
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    logger.info("Starting application")
+
+    logger.info("Creating database connection")
+    async with engine.begin() as conn:
+        try:
+            await conn.run_sync(SQLModel.metadata.create_all)
+            logger.info("Table created")
+        except Exception as e:
+            logger.error(f"Error creaing table: {e}")
+
+    
+    logger.info("Loading chain")
+    load_chain()
+
+    yield
+
+    logger.info("Shutting down")
+    await engine.dispose()
+
+
+
+app = FastAPI(lifespan=lifespan)
+app.include_router(router=router)
+
+
+@app.get("/")
+async def root():
+    return JSONResponse(content={"message": "This is the root of retrospective service api."}, status_code=200)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("main:app", host="localhost", port=8003, reload=True)

--- a/model.py
+++ b/model.py
@@ -1,0 +1,53 @@
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from langchain.callbacks.manager import CallbackManager
+from langchain.callbacks import StdOutCallbackHandler
+from langchain.prompts import PromptTemplate
+from langchain_community.llms import LlamaCpp
+from langchain.chains import LLMChain
+
+from loguru import logger
+
+from config import config
+
+
+
+chain = None
+
+
+def load_chain():
+    # https://huggingface.co/hyeogi/SOLAR-10.7B-v1.2/discussions/1
+    template = """### System:\n{input}\n\n### User:\n{instruction}\n### Assistant:\n"""
+
+    prompt = PromptTemplate.from_template(template)
+
+    callback_manager = CallbackManager([StdOutCallbackHandler()])
+
+    model_path = config.retrospective_model_path
+
+    logger.info(f"Loading model from {model_path}")
+
+    try:
+        # https://github.com/abetlen/llama-cpp-python
+        llm = LlamaCpp(
+            model_path=model_path,
+            n_gpu_layers=-1,
+            n_batch=512,
+            callback_manager=callback_manager,
+            temperature=0.6,
+            top_p=1,
+            max_tokens=128,
+            verbose=True,
+        )
+        logger.info(f"Loaded model from {model_path}")
+    except Exception as e:
+        logger.error(f"Error while loading model from {model_path}: {e}")
+        llm = None
+
+    global chain
+    chain = LLMChain(prompt=prompt, llm=llm)
+
+
+def get_chain():
+    return chain
+
+

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel, Field
+from typing import List
+
+
+class ModelGenerationRequest(BaseModel):
+    text: str
+
+class ModelGenerationResponse(BaseModel):
+    text: str
+
+
+class RetrospectiveRequest(BaseModel):
+    username: str
+    user_inputs: List[str]
+    bot_responses: List[str]
+
+
+class RetrospectiveResponse(BaseModel):
+    text: str


### PR DESCRIPTION
## Overview
-  Add basic files

## Change Log
- `main.py`
  - `lifespan` function
    -  create db connection and check if implemented table is created
    - load langchain model (`llm`)
- `config.py`
  - `Config` class
    - `db_url`: postgres server url (asynchronous support with asyncpg)
    -  `summary_model_path`: huggingface transformers model id for primary summary of conversation
    - `retrospective_model_path`: actual directory path for `.gguf` model loaded by llama cpp
- `database.py`
  - `Retrospective` class
    - table for storing result of retrospective
    - each user `username can have his own retrospective for each time point `created_at`
  - `AsyncSessionLocal` instance
    - create new connection session to db or bring existing session as needed
  - `get_db_session` function
    - dependency  to bring session from stored sessions for use in router functions
- `schemas.py`
  - `ModelGenerationRequest` and `ModelGenerationResponse` class
    - simple input, output models for testing generation of langchain llm
  - `RetrospectiveRequest` class
    - request form for generating retrospective
    - needs username and conversation data needed 
  - `RetrospectiveResponse` class
    - send back generated retrospective as a string
- `api.py`
  - POST:`/generate/chain`
    - test generation from llm
  - POST:`/predict`
    - generate retrospective and saved it to postgres db 
    - inner code will be updated after adding primary summary functionality
  - GET:`/predict/{username}` (TBU)
    - return all the retrospective of certain user
    - will be used to display retrospective page in django app
- `model.py`
  - `load_chain` function
    - load promt, llm, and finally `LLMChain`
  - `get_chain` function
    - dependency for get loaded chain

## Issue Tags
- Closed: #1 
