### PR TITLE
feat - add hf model and predict route functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Custom
 *.gguf
+test/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/api.py
+++ b/api.py
@@ -3,8 +3,10 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from langchain.chains import LLMChain
 
+import numpy as np
+
 from database import Retrospective, get_db_session
-from model import get_chain
+from model import get_tf_model, get_llm_chain
 from schemas import (
     ModelGenerationRequest,
     ModelGenerationResponse,
@@ -17,28 +19,81 @@ router = APIRouter()
 
 
 
+@router.post("/generate/tf")
+async def generate_tf_model(request: ModelGenerationRequest,
+                            tf_model: tuple = Depends(get_tf_model)) -> ModelGenerationResponse:
+    device, tokenizer, model = tf_model
+    inputs = tokenizer(request.text, return_tensors="pt", padding=True, truncation=True).to(device)
+    outputs = model.generate(
+        inputs.input_ids,
+        attention_mask=inputs.attention_mask, 
+        max_length=64, num_beams=5, length_penalty=1.2, use_cache=True, early_stopping=True
+    ).detach().cpu()
+    text = tokenizer.decode(outputs[0], skip_special_tokens=True)
+
+    return ModelGenerationResponse(text=text)
+
+
 
 @router.post("/generate/chain")
 async def generate_chain(request: ModelGenerationRequest,
-                         chain: LLMChain = Depends(get_chain)) -> ModelGenerationResponse:
+                         llm_chain: LLMChain = Depends(get_llm_chain)) -> ModelGenerationResponse:
     
     context = {
         "input": "너는 사용자에게 도움을 주는 AI야",
         "instruction": request.text
     }
     
-    result = await chain.ainvoke(input=context, max_tokens=100, temperature=0.6, top_p=1, verbose=True)
+    result = await llm_chain.ainvoke(input=context)
 
     return ModelGenerationResponse(text=result.get("text"))
 
 
+
 @router.post("/predict")
 async def predict(request: RetrospectiveRequest,
-                  chain: LLMChain = Depends(get_chain),
+                  tf_model:tuple = Depends(get_tf_model),
+                  llm_chain: LLMChain = Depends(get_llm_chain),
                   db: AsyncSession = Depends(get_db_session)) -> RetrospectiveResponse:
-    
+    device, tokenizer, model = tf_model
 
-    return RetrospectiveResponse(text="response")
+    user_inputs = request.user_inputs
+    user_inputs_length = len(user_inputs)
+
+    chunks = []
+    turns_per_chunk = 5
+    total_chunks = user_inputs_length // turns_per_chunk if user_inputs_length % turns_per_chunk == 0 else user_inputs_length // turns_per_chunk + 1
+    for i in range(total_chunks):
+        start = i * turns_per_chunk
+        end = (i + 1) * turns_per_chunk if (i + 1) * turns_per_chunk < user_inputs_length else user_inputs_length
+        chunks.append("[BOS]" + "[SEP]".join(user_inputs[start:end]) + "[EOS]")
+
+    
+    inputs = tokenizer(chunks, return_tensors="pt", padding=True, truncation=True, max_length=64).to(device)
+    outputs = model.generate(
+        inputs.input_ids,
+        attention_mask=inputs.attention_mask, 
+        max_length=64, num_beams=5, length_penalty=1.2, use_cache=True, early_stopping=True).detach().cpu()
+    summary = tokenizer.decode(outputs[0], skip_special_tokens=True)
+    summary = "".join(summary)
+
+    
+    context = {
+        "username": request.username,
+        "summary": summary,
+    }
+
+    result = await llm_chain.ainvoke(input=context)
+    result = result.get("text").strip()
+
+    retrospective = Retrospective(
+        username=request.username,
+        text=result
+    )
+    db.add(retrospective)
+    await db.commit()
+
+    return RetrospectiveResponse(text=result)
     
     
 

--- a/config.py
+++ b/config.py
@@ -12,15 +12,14 @@ DB_PASSWORD = os.environ.get("DB_PASSWORD")
 DB_HOST = os.environ.get("DB_HOST")
 DB_NAME = os.environ.get("DB_NAME")
 DB_URL = f"postgresql+asyncpg://{DB_USERNAME}:{DB_PASSWORD}@{DB_HOST}/{DB_NAME}"
-SUMMARY_MODEL_PATH = os.environ.get("SUMMARY_MODEL_PATH")
-RETROSPECTIVE_MODEL_PATH = os.environ.get("RETROSPECTIVE_MODEL_PATH")
+TF_MODEL_ID = os.environ.get("TF_MODEL_ID")
+LLM_MODEL_PATH = os.environ.get("LLM_MODEL_PATH")
 
 
 class Config(BaseSettings):
     db_url: str = Field(default=DB_URL, env="DB_URL")
-    summary_model_path: str = Field(default=SUMMARY_MODEL_PATH, env="SUMMARY_MODEL_PATH") # transformers
-    retrospective_model_path: str = Field(default=RETROSPECTIVE_MODEL_PATH, env="RETROSPECTIVE_MODEL_PATH") # langchain llamacpp gguf
-    
+    tf_model_id: str = Field(default=TF_MODEL_ID, env="TF_MODEL_ID") # transformers
+    llm_model_path: str = Field(default=LLM_MODEL_PATH, env="LLM_MODEL_PATH") # langchain llamacpp gguf
 
 
 config = Config()

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from loguru import logger
 
 from api import router
 from database import engine, Retrospective
-from model import load_chain
+from model import load_tf_model, load_llm_chain
 
 
 
@@ -23,9 +23,11 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             logger.error(f"Error creaing table: {e}")
 
+    logger.info("Loading transformers model")
+    load_tf_model()
     
-    logger.info("Loading chain")
-    load_chain()
+    logger.info("Loading llm chain")
+    load_llm_chain()
 
     yield
 

--- a/model.py
+++ b/model.py
@@ -1,30 +1,71 @@
-from transformers import AutoTokenizer, AutoModelForCausalLM
+from transformers import AutoConfig, AutoTokenizer, PreTrainedModel, BartForConditionalGeneration
 from langchain.callbacks.manager import CallbackManager
 from langchain.callbacks import StdOutCallbackHandler
 from langchain.prompts import PromptTemplate
 from langchain_community.llms import LlamaCpp
 from langchain.chains import LLMChain
 
+import torch
+
 from loguru import logger
 
 from config import config
 
 
+tf_device, tf_tokenizer, tf_model = None, None, None
+llm_chain = None
 
-chain = None
+
+def load_tf_model():
+    tf_config = AutoConfig.from_pretrained(config.tf_model_id)
+
+    global tf_device
+    tf_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    global tf_tokenizer
+    tf_tokenizer = AutoTokenizer.from_pretrained(config.tf_model_id)
+    
+    global tf_model
+    tf_model = BartForConditionalGeneration.from_pretrained(config.tf_model_id, config=tf_config).to(tf_device)
 
 
-def load_chain():
+def get_tf_model():
+    return tf_device, tf_tokenizer, tf_model
+
+
+
+
+def load_llm_chain():
     # https://huggingface.co/hyeogi/SOLAR-10.7B-v1.2/discussions/1
-    template = """### System:\n{input}\n\n### User:\n{instruction}\n### Assistant:\n"""
+    # template = """### System:\n{input}\n\n### User:\n{instruction}\n### Assistant:\n"""
+    template = """### System:
+    보고서는 {username}의 하루를 기록한 내용이야. 다음 지침과 예시를 참고해서 회고를 작성해줘.
+    1. {username}의 하루를 루나라는 친구가 평가하는 내용을 작성해줘.
+    2. 친구가 {username}에게 말해주는 것처럼 친근한 말투로 써줘.
+    3. 모든 문장을 과거형으로 작성해줘.
+
+    ### 보고서:
+    고등학교 친구인 예원이를 만나서 카페를 다녀왔다고 한다.
+    집에 돌아와서는 너무 늦게 들어왔다는 이유로 엄마와 다퉜다고 한다.
+    기분이 좋지 않았는데 대학 과제를 해야했기 때문에 열심히 다 마치고 잤다고 한다.
+
+    ### 회고:
+    {username}아! 너는 오늘 고등학교 친구 예원이랑 만나서 카페를 다녀왔었네. 재미있었어?
+    {username}는 집에 늦게 들어왔다고 엄마와 다퉜었지. 속상했겠다..
+    그리고 기분이 좋지 않았는데도 대학 과제를 마무리하고 잤구나. {username}는 대단한 것 같아!
+
+    ### 보고서:
+    {summary}
+    ### 회고:
+    """
 
     prompt = PromptTemplate.from_template(template)
 
     callback_manager = CallbackManager([StdOutCallbackHandler()])
 
-    model_path = config.retrospective_model_path
+    model_path = config.llm_model_path
 
-    logger.info(f"Loading model from {model_path}")
+    # logger.info(f"Loading model from {model_path}")
 
     try:
         # https://github.com/abetlen/llama-cpp-python
@@ -43,11 +84,11 @@ def load_chain():
         logger.error(f"Error while loading model from {model_path}: {e}")
         llm = None
 
-    global chain
-    chain = LLMChain(prompt=prompt, llm=llm)
+    global llm_chain
+    llm_chain = LLMChain(prompt=prompt, llm=llm)
 
 
-def get_chain():
-    return chain
+def get_llm_chain():
+    return llm_chain
 
 


### PR DESCRIPTION
## Overview
- Add huggingface transformers model (loading , dependency)
- Add primary summary & retrospective generation functionality on single router function `/predict`

## Change Log
- `model.py`
  - turn existing name `chain` into `llm_chain` for better distinguishment between transformers model
  - load and get transformers model (device, tokenizer, model)
- `api.py`
  - POST: `/predict`
    - divide list of user inputs into chunks
    - generate summary for each chunk via `tf_model` and concatenate all of them
    - input combined summary and generate a single retrospective string via `llm_chain`

## Issue Tags
- Closed: #3 

## Further Works
- `WebSocket` route for accepting socket connections
- turn transformers model inference part into asynchronous process
