### PR TITLE
feat - add get route, socket endpoint support, and async inference for hf model

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,12 +1,15 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, WebSocket, Depends, WebSocketDisconnect
 
+from sqlmodel import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from langchain.chains import LLMChain
 
+from loguru import logger
 import numpy as np
+from typing import Optional, List
 
 from database import Retrospective, get_db_session
-from model import get_tf_model, get_llm_chain
+from model import get_tf_model, get_llm_chain, make_summary, async_func
 from schemas import (
     ModelGenerationRequest,
     ModelGenerationResponse,
@@ -50,9 +53,23 @@ async def generate_chain(request: ModelGenerationRequest,
 
 
 
+@router.get("/predict/{username}")
+async def get_predict(username: str,
+                      db: AsyncSession = Depends(get_db_session)) -> List[RetrospectiveResponse]:
+    result = await db.execute(select(Retrospective)
+                              .filter(Retrospective.username == username)
+    )
+    retrospectives = result.scalars().all()
+    return [
+        RetrospectiveResponse(text=retrospective.text)
+        for retrospective in retrospectives
+    ]
+
+
+
 @router.post("/predict")
 async def predict(request: RetrospectiveRequest,
-                  tf_model:tuple = Depends(get_tf_model),
+                  tf_model: tuple = Depends(get_tf_model),
                   llm_chain: LLMChain = Depends(get_llm_chain),
                   db: AsyncSession = Depends(get_db_session)) -> RetrospectiveResponse:
     device, tokenizer, model = tf_model
@@ -67,16 +84,8 @@ async def predict(request: RetrospectiveRequest,
         start = i * turns_per_chunk
         end = (i + 1) * turns_per_chunk if (i + 1) * turns_per_chunk < user_inputs_length else user_inputs_length
         chunks.append("[BOS]" + "[SEP]".join(user_inputs[start:end]) + "[EOS]")
-
     
-    inputs = tokenizer(chunks, return_tensors="pt", padding=True, truncation=True, max_length=64).to(device)
-    outputs = model.generate(
-        inputs.input_ids,
-        attention_mask=inputs.attention_mask, 
-        max_length=64, num_beams=5, length_penalty=1.2, use_cache=True, early_stopping=True).detach().cpu()
-    summary = tokenizer.decode(outputs[0], skip_special_tokens=True)
-    summary = "".join(summary)
-
+    summary = await async_func(make_summary, chunks, device, tokenizer, model)
     
     context = {
         "username": request.username,
@@ -90,10 +99,76 @@ async def predict(request: RetrospectiveRequest,
         username=request.username,
         text=result
     )
+
     db.add(retrospective)
     await db.commit()
 
     return RetrospectiveResponse(text=result)
+
+
+
+@router.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket,
+                             tf_model: tuple = Depends(get_tf_model),
+                             llm_chain: LLMChain = Depends(get_llm_chain),
+                             db: AsyncSession = Depends(get_db_session)):
+    device, tokenizer, model = tf_model
+    
+    await websocket.accept()
+    await websocket.send_text("Connection successful")
+
+    try:
+        while True:
+            data = await websocket.receive_json()
+
+            if data.get("type") == "get_predict":
+                result = await db.execute(select(Retrospective)
+                              .filter(Retrospective.username == data.get("username"))
+                )
+                retrospectives = result.scalars().all()
+                
+                response = [{"text": retrospective.text} for retrospective in retrospectives]
+                await websocket.send_json(response)
+            
+            elif data.get("type") == "post_predict":
+                user_inputs = data.get("user_inputs")
+                user_inputs_length = len(user_inputs)
+
+                chunks = []
+                turns_per_chunk = 5
+                total_chunks = user_inputs_length // turns_per_chunk if user_inputs_length % turns_per_chunk == 0 else user_inputs_length // turns_per_chunk + 1
+                for i in range(total_chunks):
+                    start = i * turns_per_chunk
+                    end = (i + 1) * turns_per_chunk if (i + 1) * turns_per_chunk < user_inputs_length else user_inputs_length
+                    chunks.append("[BOS]" + "[SEP]".join(user_inputs[start:end]) + "[EOS]")
+                
+                summary = await async_func(make_summary, chunks, device, tokenizer, model)
+                
+                context = {
+                    "username": data.get("username"),
+                    "summary": summary,
+                }
+
+                result = await llm_chain.ainvoke(input=context)
+                result = result.get("text").strip()
+
+                retrospective = Retrospective(
+                    username=data.get("username"),
+                    text=result
+                )
+
+                db.add(retrospective)
+                await db.commit()
+
+                response = {"text": result} #  if reference result from retrospective.text, must await db.refresh(retrospective)
+                await websocket.send_json(response)
+            
+            else:
+                await websocket.send_json({"error": "Invalid request type."})
+
+    except WebSocketDisconnect:
+        logger.info("WebSocket client disconnected")
+
     
     
 

--- a/schemas.py
+++ b/schemas.py
@@ -2,8 +2,10 @@ from pydantic import BaseModel, Field
 from typing import List
 
 
+
 class ModelGenerationRequest(BaseModel):
     text: str
+
 
 class ModelGenerationResponse(BaseModel):
     text: str
@@ -17,3 +19,4 @@ class RetrospectiveRequest(BaseModel):
 
 class RetrospectiveResponse(BaseModel):
     text: str
+


### PR DESCRIPTION
## Overview
- Add get route for getting specific user's previous retrospectives
- Add socket endpoint support $\rightarrow$ do exactly same operation with in the same data format
- Support asynchronous inference for transformers model

## Change Log
- `api.py`
  - WebSocket: `/ws`
    - GET: `/predict` $\rightarrow$ `{"type": "get_predict"}`
    - POST: `/predict` $\rightarrow$ `{"type": "post_predict"}`
    - request and response data shape are the same as defined in `schemas.py`
- `model.py`
  - `async_func` function
    - turn any synchronous function to be executed asynchronously
    - `asyncio.get_event_loop()`
      - retrieves the event loop that is currently running in the current thread
    - `ThreadPoolExecutor()`
      - a collection of worker threads that efficiently execute calls asynchronously
      - setting up a pool of threads
      - run tasks in parallel in different threads, making your application more efficient, especially for I/O-bound tasks
    - `loop.run_in_executor()`
  - `make_summary` function
    - wrap up function for tokenizing, generating, and returning summary from chunked user inputs

## To Reviewer
- Why we use async?
  - transformers model inference is primarily conducted in GPU. So, it does need GPU I/O and to wait until GPU to run model

## Issue Tags
- Closed: #5 
